### PR TITLE
fix typo for record declaration

### DIFF
--- a/syntaxes/purescript.json
+++ b/syntaxes/purescript.json
@@ -246,7 +246,7 @@
           }
         },
         {
-          "name": "meta.declaratyion.type.data.record.block.purescript",
+          "name": "meta.declaration.type.data.record.block.purescript",
           "begin": "\\{",
           "beginCaptures": {
             "0": {


### PR DESCRIPTION
I think this typo was blocking the highlight of simple record declaration. (works with data/newtype)

![image](https://cloud.githubusercontent.com/assets/1443499/24200445/5f603074-0f0d-11e7-9a6b-8f73db2603dc.png)
