### PR TITLE
Add syntax highlighting for purescript/purs code blocks in markdown.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,16 @@
                 "language": "purescript",
                 "scopeName": "source.purescript",
                 "path": "./syntaxes/purescript.json"
+            },
+            {
+                "scopeName": "markdown.purescript.codeblock",
+                "path": "./syntaxes/codeblock-purescript.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.purescript": "purescript"
+                }
             }
         ],
         "snippets": [

--- a/syntaxes/codeblock-purescript.json
+++ b/syntaxes/codeblock-purescript.json
@@ -1,0 +1,28 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:markup.fenced_code.block.markdown",
+  "patterns": [
+    {
+      "include": "#purescript-code-block"
+    }
+  ],
+  "repository": {
+    "purescript-code-block": {
+      "begin": "\\b(purescript|purs)\\b(\\s+[^`~]*)?$",
+      "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.purescript",
+          "patterns": [
+            {
+              "include": "source.purescript"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.purescript.codeblock"
+}


### PR DESCRIPTION
The code is based on https://github.com/JustusAdam/language-haskell. I just replaced `haskell` with `purescript` and `hs` with `purs`.

Here's a preview of what this does:

<img width="383" alt="screen shot 2018-09-18 at 9 45 53 pm" src="https://user-images.githubusercontent.com/217126/45701522-16141d80-bb8d-11e8-9f0f-9bd04a5e9b64.png">