### PR TITLE
define indentation rules

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,12 @@ const configuration : vscode.LanguageConfiguration = {
 		["(", ")"],
 		["\"", "\""],
 		["`", "`"]
-	]
+	],
+	"indentationRules": {
+		// indent if:                   |-where w/o firstline-| |- ends with keyword            -| |- ends with unapplied op                                                 -|    |-unmatched brackets (depth 1)-|
+		"increaseIndentPattern": /^\s*(((?!module).)+(.*)where|(.*)\b(do|let|in|if|then|else|of)\b|((.*)[$\.:\+\-\*\=/%><#:\u2200-\u22FF\u27C0-\u27EF\u2980-\u29FF\u2A00-\u2AFF]+)|(.*(\[[^\]]+|\{[^\}]+|\([^\)]+))|(,.*))\s*$/,
+		"decreaseIndentPattern": /^\s*[\]\,\)\}].*$/,
+	}
 };
 
 export function activate() {


### PR DESCRIPTION
Improved version of https://github.com/nwolverson/vscode-language-purescript/pull/11

- does not decrease identation for `in` as there is no good way to distinguish a word starting with "in" like "inList" from the keyword `in`
- places the config in the typescript file (=> increased stability)
- do not indent after `when` if it is in the same line as module declaration (better than the haskell indent rules ;))
- handling of `{}` brackets and `,`
