### PR TITLE
add local/remote update script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,6 @@ This repository contains generated code based on [atom-language-purescript](http
 * For snippets changes, edit `snippets/language-purescript.cson` in `atom-language-purescript`
 * For grammar changes, edit `src/purescript.coffee` and (in atom-language purescript) run `npm run build`
 
-Changes are pulled in from `atom-language-purescript` by `npm run build` here.
+Changes are pulled in from upstream repository `atom-language-purescript` by `npm run build` here.
+
+You may also pull in changes from a locally cloned version of `atom-language-purescript` by running `node scripts/update --local [path-to cloned repo]` (by default the path is "../atom-language-purescript" relative to the current directory).

--- a/scripts/update-grammar.js
+++ b/scripts/update-grammar.js
@@ -1,16 +1,3 @@
-var request = require('request');
-var cson = require('cson');
-var process = require('process');
-var fs = require('fs');
+process.argv.push("--grammar");
 
-var url = 'https://raw.githubusercontent.com/purescript-contrib/atom-language-purescript/master/grammars/purescript.cson';
-request(url, function (error, response, body) {
-	if (error) {
-		console.error(error);
-		process.exit(1);
-	} else {
-		var obj = cson.parse(body);
-		var json = cson.createJSONString(obj);
-		fs.writeFileSync('syntaxes/purescript.json', json)
-	}
-});
+require("./update");

--- a/scripts/update-snippets.js
+++ b/scripts/update-snippets.js
@@ -1,16 +1,3 @@
-var request = require('request');
-var cson = require('cson');
-var process = require('process');
-var fs = require('fs');
+process.argv.push("--snippets");
 
-var url = 'https://raw.githubusercontent.com/purescript-contrib/atom-language-purescript/master/snippets/language-purescript.cson';
-request(url, function (error, response, body) {
-	if (error) {
-		console.error(error);
-		process.exit(1);
-	} else {
-		var obj = cson.parse(body)[".source.purescript"];
-		var json = cson.createJSONString(obj);
-		fs.writeFileSync('snippets/purescript.json', json)
-	}
-});
+require("./update");

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -1,0 +1,80 @@
+// @ts-check
+const request = require("request");
+const cson = require("cson");
+const process = require("process");
+const fs = require("fs");
+const path = require("path");
+
+const upstreamName = "atom-language-purescript";
+
+const getUrl = (file) =>
+  "https://raw.githubusercontent.com/purescript-contrib/" +
+  upstreamName +
+  "/master/" +
+  file;
+
+const locFilesMap = {
+  snippets: "snippets/purescript.json",
+  grammar: "syntaxes/purescript.json",
+};
+
+const remoteFilesMap = {
+  snippets: "snippets/language-purescript.cson",
+  grammar: "grammars/purescript.cson",
+};
+
+const args = process.argv.slice(2);
+const getArg = (flag, defaultVal) => {
+  const index = args.indexOf("--" + flag);
+  if (index >= 0) {
+    const val = args[index + 1];
+    return val && !val.startsWith("-") ? val : defaultVal;
+  }
+  return null;
+};
+
+const update = (updateFn) => {
+  const upSnippets = args.includes("--snippets");
+  const upGrammar = args.includes("--grammar");
+  const all = !upSnippets && !upGrammar  
+  if (all || upGrammar) {
+    updateFn("grammar");
+  }
+  if (all || upSnippets) {
+    updateFn("snippets");
+  }
+};
+
+const updateFile = (file, error, body) => {
+  if (error) {
+    console.error(error);
+    process.exit(1);
+  } else {
+    const obj = cson.parse(body);
+    const json = cson.createJSONString(obj);
+    fs.writeFileSync(file, json);
+  }
+};
+
+const local = getArg("local", path.join(__dirname, "../..", upstreamName));
+
+// if --local option is passed
+if (local) {
+  const updateFromFs = (what) => {
+    const filePath = path.join(local, remoteFilesMap[what]);
+    console.log("Updating from", filePath);
+    fs.readFile(filePath, "utf-8", (error, text) => {
+      updateFile(locFilesMap[what], error, text);
+    });
+  };
+  update(updateFromFs);
+} else {
+  const updateFromUrl = (what) => {
+    const url = getUrl(remoteFilesMap[what]);
+    console.log("Updating from", url);
+    request(url, (error, _, body) => {
+      updateFile(locFilesMap[what], error, body);
+    });
+  };
+  update(updateFromUrl);
+}


### PR DESCRIPTION
This one enhances `update` script, which allows updating from locally cloned `atom-language-purescript` repo, not only from the remote repo, useful while development.

Current usage  is: `node scripts/update --local` (didn't update `package.json` scripts).